### PR TITLE
Serialize data fix if object is Hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+/tmp
 .DS_Store
+/.idea/

--- a/lib/trustly/api.rb
+++ b/lib/trustly/api.rb
@@ -12,7 +12,7 @@ class Trustly::Api
       end
     elsif object.is_a?(Hash)
       # Its a Hash
-      object.sort.to_h.each do |key,value|
+      Hash[object.sort.each{}].each do |key,value|
         serialized.concat(key.to_s).concat(serialize_data(value))
       end
     else


### PR DESCRIPTION
``` ruby
object.sort.to_h
```

in api.rb was causing NoMethodError: undefined method `to_h' for #Array:..... I'm using ruby-2.0.0@353
