### PR TITLE
Adding Email to deposit attributes

### DIFF
--- a/lib/trustly/api/signed.rb
+++ b/lib/trustly/api/signed.rb
@@ -99,7 +99,7 @@ class Trustly::Api::Signed < Trustly::Api
       "Currency","Country","IP",
       "SuccessURL","FailURL","TemplateURL","URLTarget",
       "MobilePhone","Firstname","Lastname","NationalIdentificationNumber",
-      "ShopperStatement"
+      "Email", "ShopperStatement"
     )
 
     data       = options.slice("NotificationURL","EndUserID","MessageID")


### PR DESCRIPTION
Trustly now requires Email attribute in deposit calls
